### PR TITLE
changes CI package installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           pkg-manager: pip
       - run:
           name: "install nrelpy"
-          command: pip install nrelpy
+          command: pip install ./
       - run:
           name: "pytest"
           command: pytest

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ import sys
 import os
 from setuptools import setup, find_packages
 
-from pygenesys.setup import ENTRY_POINTS
-
 PACKAGES = find_packages()
 
 # Get version and release info, which is all stored in shablona/version.py

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import sys
 import os
 from setuptools import setup, find_packages
 
+from pygenesys.setup import ENTRY_POINTS
+
 PACKAGES = find_packages()
 
 # Get version and release info, which is all stored in shablona/version.py
@@ -9,7 +11,7 @@ ver_file = os.path.join('nrelpy', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
 
-
+ENTRY_POINTS = {}
 
 # Give setuptools a hint to complain if it's too old a version
 # 24.2.0 added the python_requires option


### PR DESCRIPTION
Currently, the `config.yml` file installs `nrelpy` using `pip install nrelpy`. However, this method will only install the version that is currently on pypi and not the development version (i.e. the version that needs to be tested). This PR changes the behavior to `pip install ./` which should install the correct version of `nrelpy`.