### PR TITLE
Adds working ATBe class

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,5 @@ omit =
     nrelpy/**/__init__.py
     setup.py
     nrelpy/version.py
+    version.py
+    __init__.py

--- a/nrelpy/atb.py
+++ b/nrelpy/atb.py
@@ -145,6 +145,10 @@ class ATBe(object):
             technology selection. For example, `LandbasedWind`
             has data for multiple wind classes (e.g. `Class9`).
             This must be specified in order to distinguish values.
+        value_only : boolean
+            An optional parameter that indicates whether the
+            value is returned as a Unyt object or as the value
+            only. Default is True.
         """
 
         self.dataframe

--- a/nrelpy/atb.py
+++ b/nrelpy/atb.py
@@ -118,9 +118,10 @@ class ATBe(object):
         ['Advanced']
         """
         df = as_dataframe(year=self.year, database=self.database)
+        # breakpoint()
         df = df[(df.core_metric_case == self.case) &
                 (df.scenario == self.scenario) &
-                (df.crpyears) == str(self.crp)]
+                (df.crpyears == str(self.crp))]
         return df
 
     @property
@@ -129,7 +130,7 @@ class ATBe(object):
         The list of available technologies for the current ATBe.
         """
 
-        return np.sort(self.dataframe.technology.unique())
+        return (self.dataframe.technology.unique())
 
     @property
     def available_metric(self):
@@ -162,7 +163,7 @@ class ATBe(object):
             has data for multiple wind classes (e.g. `Class9`).
             This must be specified in order to distinguish values.
         projection_year : int or list of int
-            The desired data year or set of years.
+            The desired data year or set of years. Default is 2020.
         value_only : boolean
             An optional parameter that indicates whether the
             value is returned as a Unyt object or as the value
@@ -170,35 +171,48 @@ class ATBe(object):
 
         Returns
         -------
-        datum : unyt.Quantity or float
+        value : unyt.Quantity or float
             The technology datum of interest
+        unit : string
+            Only returned if `value_only` is set to False.
+            Currently a string representation of the unit.
         """
 
+        df = self.dataframe.copy()
+
         tech_fail_str = (f"{technology} not in list of available techs. \n" +       
-                        f"Try one of {self.available_tech}")
+                        f"Try one of \n {self.available_tech}")
         param_fail_str = (f"{core_metric_param} not in list of metrics. \n" +
-                        f"Try one of {self.available_metric}")
+                        f"Try one of \n {self.available_metric}")
         assert technology in self.available_tech, tech_fail_str
         assert core_metric_param in self.available_metric, param_fail_str
 
-        detail_mask = self.dataframe['techdetail'] == techdetail
-        detail_list = self.dataframe[detail_mask]
+        # mask the techs and params
+        df = df[(df['technology'] == technology) &
+                (df['core_metric_parameter'] == core_metric_param)]
         
-        
-        
+        detail_list = df['techdetail'].unique()
+        detail_fail_str = (f"{techdetail} not in list of details for " + 
+                            f"technology {technology}. \n" +
+                            f"Try one of \n {detail_list}")
+        assert techdetail in detail_list, detail_fail_str
 
-        return
+        # mask the detail
+        detail_mask = df['techdetail'] == techdetail
+        df = df[detail_mask]
 
+        # mask the year
+        if isinstance(projection_year, int):
+            df = df[df['core_metric_variable'] == projection_year]
+            assert len(df) > 0, f"{projection_year} not in ATBe."
+        elif isinstance(projection_year, list):
+            df = df[df['core_metric_variable'].isin(projection_year)]
+            assert len(df) == len(projection_year), "Some years not in ATBe"
 
-if __name__ == "__main__":
+        unit = df.units.values[0]
+        value = df.value.values[0]
 
-    year = 2022
-    atb_class = ATBe(year=2022)
-
-    print(atb_class.scenario)
-
-    print(atb_class.dataframe.scenario.unique())
-
-    atb_class.scenario = 'Advanced'
-
-    print(atb_class.dataframe.scenario.unique())
+        if value_only:
+            return value
+        else: 
+            return value, unit

--- a/nrelpy/atb.py
+++ b/nrelpy/atb.py
@@ -57,3 +57,110 @@ def as_dataframe(year, database, verbose=False, **kwargs):
         save_local(df, database=database, year=year)
 
     return df
+
+
+class ATBe(object):
+    """
+    A class that allows simplified access to the various
+    cases and data values.
+    """
+
+    def __init__(
+            self,
+            year,
+            database='electricity',
+            case='R&D',
+            scenario='Moderate',
+            crp = '20',
+            **kwargs) -> None:
+        """
+        Initializes the ATB class.
+
+        Parameters
+        ----------
+        year : int
+            Specifies the ATB year
+        database : string
+            Specifies which ATB database. 
+            Accepts ['electricity', 'transportation']
+            Default is 'electricity'.
+        case : string
+            Specifies the technology case. 
+            Accepts ['Market', 'R&D']
+        scenario : string
+            Specifies the technology scenario. 
+            Accepts ['Conservative', 'Moderate', 'Advanced']
+        crp : string or int
+            `crp` stands for "cost recovery period." This parameter only
+            influences the levelized cost of electricity (LCOE) 
+            calculation. Default is 20 years.
+        """
+
+        self.year = year
+        self.database = database
+        self.case = case
+        self.scenario = scenario
+        self.crp = crp
+
+
+    @property
+    def dataframe(self):
+        """
+        Creates a subset of the ATBe according to the settings
+        stored as class attributes. Updates whenever a setting
+        is changed.
+        
+        >>> atbe = ATBe(2022)
+        >>> print(atbe.dataframe.scenario.unique())
+        ['Moderate']
+        >>> atbe.scenario = 'Advanced'
+        >>> print(atbe.dataframe.scenario.unique())
+        ['Advanced']
+        """
+        df = as_dataframe(year=self.year, database=self.database)
+        df = df[(df.core_metric_case == self.case) &
+                (df.scenario == self.scenario) &
+                (df.crpyears) == str(self.crp)]
+        return df
+
+
+    def get_data(self, 
+                technology, 
+                core_metric_param, 
+                techdetail,
+                value_only=True):
+        """
+        Retrieves a specific piece of technology data.
+
+        Parameters
+        ----------
+        technology : string
+            Specifies the technology. 
+        core_metric_param : string
+            The parameter of interest.
+            Accepts ['CAPEX', 'Fixed O&M', 'Variable O&M', 
+                    'Fuel', 'CF', 'LCOE']
+        techdetail : string
+            A more descriptive parameter to narrow down
+            technology selection. For example, `LandbasedWind`
+            has data for multiple wind classes (e.g. `Class9`).
+            This must be specified in order to distinguish values.
+        """
+
+        self.dataframe
+
+
+
+if __name__ == "__main__":
+
+    
+    year = 2022
+    atb_class = ATBe(year=2022)
+
+    print(atb_class.scenario)
+
+    print(atb_class.dataframe.scenario.unique())
+
+    atb_class.scenario = 'Advanced'
+
+    print(atb_class.dataframe.scenario.unique())

--- a/nrelpy/atb.py
+++ b/nrelpy/atb.py
@@ -1,5 +1,6 @@
 from urllib.error import HTTPError
 import pandas as pd
+import numpy as np
 from nrelpy.utils.data_io import check_stored_data, save_local
 
 
@@ -71,7 +72,7 @@ class ATBe(object):
             database='electricity',
             case='R&D',
             scenario='Moderate',
-            crp = '20',
+            crp='20',
             **kwargs) -> None:
         """
         Initializes the ATB class.
@@ -81,18 +82,18 @@ class ATBe(object):
         year : int
             Specifies the ATB year
         database : string
-            Specifies which ATB database. 
+            Specifies which ATB database.
             Accepts ['electricity', 'transportation']
             Default is 'electricity'.
         case : string
-            Specifies the technology case. 
+            Specifies the technology case.
             Accepts ['Market', 'R&D']
         scenario : string
-            Specifies the technology scenario. 
+            Specifies the technology scenario.
             Accepts ['Conservative', 'Moderate', 'Advanced']
         crp : string or int
             `crp` stands for "cost recovery period." This parameter only
-            influences the levelized cost of electricity (LCOE) 
+            influences the levelized cost of electricity (LCOE)
             calculation. Default is 20 years.
         """
 
@@ -102,14 +103,13 @@ class ATBe(object):
         self.scenario = scenario
         self.crp = crp
 
-
     @property
     def dataframe(self):
         """
         Creates a subset of the ATBe according to the settings
         stored as class attributes. Updates whenever a setting
         is changed.
-        
+
         >>> atbe = ATBe(2022)
         >>> print(atbe.dataframe.scenario.unique())
         ['Moderate']
@@ -123,41 +123,75 @@ class ATBe(object):
                 (df.crpyears) == str(self.crp)]
         return df
 
+    @property
+    def available_tech(self):
+        """
+        The list of available technologies for the current ATBe.
+        """
 
-    def get_data(self, 
-                technology, 
-                core_metric_param, 
-                techdetail,
-                value_only=True):
+        return np.sort(self.dataframe.technology.unique())
+
+    @property
+    def available_metric(self):
+        """
+        The list of available metrics for the current ATBe.
+        """
+
+        return np.sort(self.dataframe.core_metric_parameter.unique())
+
+    def get_data(self,
+                 technology,
+                 core_metric_param,
+                 techdetail,
+                 projection_year=2020,
+                 value_only=True):
         """
         Retrieves a specific piece of technology data.
 
         Parameters
         ----------
         technology : string
-            Specifies the technology. 
+            Specifies the technology.
         core_metric_param : string
             The parameter of interest.
-            Accepts ['CAPEX', 'Fixed O&M', 'Variable O&M', 
+            Accepts ['CAPEX', 'Fixed O&M', 'Variable O&M',
                     'Fuel', 'CF', 'LCOE']
         techdetail : string
             A more descriptive parameter to narrow down
             technology selection. For example, `LandbasedWind`
             has data for multiple wind classes (e.g. `Class9`).
             This must be specified in order to distinguish values.
+        projection_year : int or list of int
+            The desired data year or set of years.
         value_only : boolean
             An optional parameter that indicates whether the
             value is returned as a Unyt object or as the value
             only. Default is True.
+
+        Returns
+        -------
+        datum : unyt.Quantity or float
+            The technology datum of interest
         """
 
-        self.dataframe
+        tech_fail_str = (f"{technology} not in list of available techs. \n" +       
+                        f"Try one of {self.available_tech}")
+        param_fail_str = (f"{core_metric_param} not in list of metrics. \n" +
+                        f"Try one of {self.available_metric}")
+        assert technology in self.available_tech, tech_fail_str
+        assert core_metric_param in self.available_metric, param_fail_str
 
+        detail_mask = self.dataframe['techdetail'] == techdetail
+        detail_list = self.dataframe[detail_mask]
+        
+        
+        
+
+        return
 
 
 if __name__ == "__main__":
 
-    
     year = 2022
     atb_class = ATBe(year=2022)
 

--- a/nrelpy/tests/test_atb.py
+++ b/nrelpy/tests/test_atb.py
@@ -1,4 +1,5 @@
-from nrelpy.atb import *
+from nrelpy.atb import as_dataframe, ATBe
+from urllib.error import HTTPError
 import pytest
 
 good_year = 2020
@@ -74,3 +75,28 @@ def test_as_dataframe_bad_database():
     assert (e.type == KeyError)
 
     return
+
+
+def test_ATB_init():
+
+    atb_class = ATB(year=2022)
+
+    assert atb_class.scenario == 'Moderate'
+    assert atb_class.case == 'R&D'
+    assert atb_class.year == 2022
+    assert atb_class.dataframe.scenario.unique() == ['Moderate']
+
+    return
+
+def test_ATB_scenario_change():
+    
+    atb_class = ATBe(year=2022)
+
+    assert atb_class.dataframe.scenario.unique() == ['Moderate']
+    assert atb_class.dataframe.core_metric_case.unique() == ['R&D']
+
+    atb_class.scenario = 'Advanced'
+    atb_class.case = 'Market'
+    assert atb_class.dataframe.scenario.unique() == ['Advanced']
+    assert atb_class.dataframe.core_metric_case.unique() == ['Market']
+

--- a/nrelpy/tests/test_atb.py
+++ b/nrelpy/tests/test_atb.py
@@ -79,7 +79,7 @@ def test_as_dataframe_bad_database():
 
 def test_ATB_init():
 
-    atb_class = ATB(year=2022)
+    atb_class = ATBe(year=2022)
 
     assert atb_class.scenario == 'Moderate'
     assert atb_class.case == 'R&D'

--- a/nrelpy/tests/test_atb.py
+++ b/nrelpy/tests/test_atb.py
@@ -6,6 +6,13 @@ good_year = 2020
 bad_year = -999
 nonexistent_year = 2000
 
+good_tech = 'Nuclear'
+good_detail = 'NuclearSMR'
+good_metric = 'CAPEX'
+bad_tech = 'Dark Matter Engine'
+bad_detail = 'PlanetExpress'
+bad_metric = 'Kajiggers'
+
 def test_as_dataframe_electricity_good_year():
     database = 'electricity'
 
@@ -99,4 +106,18 @@ def test_ATB_scenario_change():
     atb_class.case = 'Market'
     assert atb_class.dataframe.scenario.unique() == ['Advanced']
     assert atb_class.dataframe.core_metric_case.unique() == ['Market']
+
+
+
+atb_class = ATBe(year=2022)
+def test_ATB_get_data_good_values():
+    exp_value = 7988.95108
+    actual_value = atb_class.get_data(good_tech, good_metric, good_detail)
+    assert (abs(exp_value - actual_value) < 1e-5)
+
+def test_ATB_get_data_bad_values():
+    with pytest.raises(AssertionError):
+        atb_class.get_data(bad_tech, good_metric, good_detail)
+        atb_class.get_data(good_tech, bad_metric, good_detail)
+        atb_class.get_data(good_tech, good_metric, bad_detail)
 

--- a/nrelpy/utils/data_io.py
+++ b/nrelpy/utils/data_io.py
@@ -4,7 +4,6 @@ import pandas as pd
 import glob
 import os
 
-# curr_dir = Path().absolute()
 curr_dir_os = Path(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = (curr_dir_os / Path('..')).resolve() / 'data'
 DATA_PATH.mkdir(exist_ok=True)


### PR DESCRIPTION
This PR adds a class that facilitates simpler access for different data points in the ATBe (electricity). 

The basic usage is

```python
from nrelpy.atb import ATBe

atbe = ATBe(year=2022)
print(atbe.get_data('LandbasedWind', 'CAPEX', 'Class9'))
# value in $/kW
```
Due to the highly detailed nature of NREL's ATBe, users must provide a "technical detail" that allows it to be distinguished from other versions of the same technology. 

Appropriate tests have been added to the testing suite.